### PR TITLE
Compare branch maps when comparing interval sets

### DIFF
--- a/rust/src/interval_set.rs
+++ b/rust/src/interval_set.rs
@@ -147,9 +147,9 @@ type TupperIntervalVec = SmallVec<TupperIntervalVecBackingArray>;
 ///
 /// Notes on the traits [`PartialEq`], [`Eq`] and [`Hash`]:
 ///
-/// - Unlike [`DecInterval`], the traits distinguish interval sets that have different decorations.
+/// - Unlike [`DecInterval`], the traits distinguish interval sets with different decorations.
 ///
-/// - The traits are sensitive to the order by which the intervals are inserted.
+/// - The traits are sensitive to the order by which the intervals have been inserted.
 ///   To compare interval sets, you first need to call `normalize(true)` on them.
 #[derive(Clone, Debug)]
 pub struct TupperIntervalSet {


### PR DESCRIPTION
This change improves the testability of `TupperIntervalSet` and prevents future errors. It does not change the semantics of existing code. The impact on performance is almost negligible.

The following statement in the doc comment of `TupperIntervalSet` has no longer been true, but was overlooked until now:

```
/// ... these traits are only used
/// during construction of [`Relation`](crate::relation::Relation)s, ...
```