### PR TITLE
Efficient algorithm for plotting explicit relations

### DIFF
--- a/rust/src/bin/graph.rs
+++ b/rust/src/bin/graph.rs
@@ -1,6 +1,7 @@
 use clap::{App, AppSettings, Arg, ArgSettings};
 use graphest::{
-    Graph, GraphingStatistics, Implicit, InexactRegion, Parametric, Relation, RelationType,
+    Explicit, Graph, GraphingStatistics, Implicit, InexactRegion, Parametric, Relation,
+    RelationType,
 };
 use image::{GrayAlphaImage, LumaA, Rgb, RgbImage};
 use inari::{const_interval, interval, Interval};
@@ -107,6 +108,12 @@ fn main() {
     let region = InexactRegion::new(bounds[0], bounds[1], bounds[2], bounds[3]);
 
     match rel.relation_type() {
+        RelationType::ExplicitFunctionOfX => plot(
+            Explicit::new(rel, region, size[0], size[1], mem_limit),
+            gray_alpha,
+            size,
+            output,
+        ),
         RelationType::Parametric => plot(
             Parametric::new(rel, region, size[0], size[1], mem_limit),
             gray_alpha,

--- a/rust/src/bin/graph.rs
+++ b/rust/src/bin/graph.rs
@@ -108,7 +108,7 @@ fn main() {
     let region = InexactRegion::new(bounds[0], bounds[1], bounds[2], bounds[3]);
 
     match rel.relation_type() {
-        RelationType::ExplicitFunctionOfX => plot(
+        RelationType::ExplicitFunctionOfX | RelationType::ExplicitFunctionOfY => plot(
             Explicit::new(rel, region, size[0], size[1], mem_limit),
             gray_alpha,
             size,

--- a/rust/src/block.rs
+++ b/rust/src/block.rs
@@ -460,6 +460,14 @@ impl BlockQueue {
     }
 }
 
+impl Extend<Block> for BlockQueue {
+    fn extend<T: IntoIterator<Item = Block>>(&mut self, iter: T) {
+        for b in iter {
+            self.push_back(b);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/src/graph.rs
+++ b/rust/src/graph.rs
@@ -91,9 +91,11 @@ pub trait Graph {
     fn refine(&mut self, duration: Duration) -> Result<bool, GraphingError>;
 }
 
+mod explicit;
 mod implicit;
 mod parametric;
 
 pub use crate::region::InexactRegion;
+pub use explicit::Explicit;
 pub use implicit::Implicit;
 pub use parametric::Parametric;

--- a/rust/src/graph.rs
+++ b/rust/src/graph.rs
@@ -5,31 +5,6 @@ use std::{
     time::Duration,
 };
 
-/// The graphing status of a pixel.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum PixelState {
-    /// There may be or may not be a solution in the pixel.
-    Uncertain,
-    /// Uncertain but we can't prove absence of solutions due to subdivision limit.
-    UncertainNeverFalse,
-    /// There are no solutions in the pixel.
-    False,
-    /// There is at least one solution in the pixel.
-    True,
-}
-
-impl Default for PixelState {
-    fn default() -> Self {
-        PixelState::Uncertain
-    }
-}
-
-/// The index of a [`Block`](crate::block::Block) in a [`BlockQueue`](crate::block::BlockQueue).
-///
-/// Indices returned by the methods of [`BlockQueue`](crate::block::BlockQueue) are [`usize`],
-/// but [`u32`] would be large enough.
-pub type QueuedBlockIndex = u32;
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum GraphingErrorKind {
     BlockIndexOverflow,
@@ -91,6 +66,7 @@ pub trait Graph {
     fn refine(&mut self, duration: Duration) -> Result<bool, GraphingError>;
 }
 
+mod common;
 mod explicit;
 mod implicit;
 mod parametric;

--- a/rust/src/graph/common.rs
+++ b/rust/src/graph/common.rs
@@ -1,0 +1,65 @@
+use inari::{const_interval, interval, Interval};
+
+/// The index of a [`Block`](crate::block::Block) in a [`BlockQueue`](crate::block::BlockQueue).
+///
+/// Indices returned by the methods of [`BlockQueue`](crate::block::BlockQueue) are [`usize`],
+/// but [`u32`] would be large enough.
+pub type QueuedBlockIndex = u32;
+
+/// The graphing status of a pixel.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PixelState {
+    /// There may be or may not be a solution in the pixel.
+    Uncertain,
+    /// Uncertain but we can't prove absence of solutions due to subdivision limit.
+    UncertainNeverFalse,
+    /// There are no solutions in the pixel.
+    False,
+    /// There is at least one solution in the pixel.
+    True,
+}
+
+impl Default for PixelState {
+    fn default() -> Self {
+        PixelState::Uncertain
+    }
+}
+
+pub fn point_interval(x: f64) -> Interval {
+    interval!(x, x).unwrap()
+}
+
+pub fn point_interval_possibly_infinite(x: f64) -> Interval {
+    if x == f64::NEG_INFINITY {
+        const_interval!(f64::NEG_INFINITY, f64::MIN)
+    } else if x == f64::INFINITY {
+        const_interval!(f64::MAX, f64::INFINITY)
+    } else {
+        point_interval(x)
+    }
+}
+
+/// Returns a number within the interval whose significand is as short as possible in the binary
+/// representation. For such inputs, arithmetic expressions are more likely to be evaluated
+/// exactly.
+///
+/// Precondition: the interval is nonempty.
+pub fn simple_fraction(x: Interval) -> f64 {
+    let a = x.inf();
+    let b = x.sup();
+    let a_bits = a.to_bits();
+    let b_bits = b.to_bits();
+    let diff = a_bits ^ b_bits;
+    // The number of leading equal bits.
+    let n = diff.leading_zeros();
+    if n == 64 {
+        return a;
+    }
+    // Set all bits from the MSB through the first differing bit.
+    let mask = !0u64 << (64 - n - 1);
+    if a <= 0.0 {
+        f64::from_bits(a_bits & mask)
+    } else {
+        f64::from_bits(b_bits & mask)
+    }
+}

--- a/rust/src/graph/common.rs
+++ b/rust/src/graph/common.rs
@@ -1,21 +1,16 @@
 use inari::{const_interval, interval, Interval};
 
-/// The index of a [`Block`](crate::block::Block) in a [`BlockQueue`](crate::block::BlockQueue).
-///
-/// Indices returned by the methods of [`BlockQueue`](crate::block::BlockQueue) are [`usize`],
-/// but [`u32`] would be large enough.
-pub type QueuedBlockIndex = u32;
-
 /// The graphing status of a pixel.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum PixelState {
-    /// There may be or may not be a solution in the pixel.
+    /// The pixel may or may not contain a solution.
     Uncertain,
-    /// Uncertain but we can't prove absence of solutions due to subdivision limit.
+    /// The same as [`PixelState::Uncertain`] but the pixel has reached the subdivision limit,
+    /// so we cannot prove absence of solutions.
     UncertainNeverFalse,
-    /// There are no solutions in the pixel.
+    /// The pixel does not contain a solution.
     False,
-    /// There is at least one solution in the pixel.
+    /// The pixel contains a solution.
     True,
 }
 
@@ -25,10 +20,26 @@ impl Default for PixelState {
     }
 }
 
+/// The index of a [`Block`](crate::block::Block) in a [`BlockQueue`](crate::block::BlockQueue).
+///
+/// While [`BlockQueue::begin_index`](crate::block::BlockQueue::begin_index)/[`BlockQueue::end_index`](crate::block::BlockQueue::begin_index) return [`usize`],
+/// [`u32`] would be large enough.
+pub type QueuedBlockIndex = u32;
+
+/// Returns the interval \[`x`, `x`\].
+///
+/// Panics if `x` is infinite or NaN.
 pub fn point_interval(x: f64) -> Interval {
     interval!(x, x).unwrap()
 }
 
+/// Returns the interval:
+///
+/// - \[`x`, `x`\] if `x` is finite,
+/// - \[−∞, [`f64::MIN`]\] if `x` is −∞, or
+/// - \[[`f64::MAX`], +∞\] if `x` is +∞.
+///
+/// Panics if `x` is NaN.
 pub fn point_interval_possibly_infinite(x: f64) -> Interval {
     if x == f64::NEG_INFINITY {
         const_interval!(f64::NEG_INFINITY, f64::MIN)

--- a/rust/src/graph/explicit.rs
+++ b/rust/src/graph/explicit.rs
@@ -189,6 +189,10 @@ impl Explicit {
         }
     }
 
+    /// Tries to prove or disprove the existence of a solution in the block
+    /// and if it is unsuccessful, returns pixels that possibly contains a solution.
+    ///
+    /// Precondition: the block is either a pixel or a superpixel.
     fn process_block(&mut self, b: &Block) -> Vec<PixelRegion> {
         let x = {
             let u_up = self.block_to_region_clipped(b).outer();
@@ -237,6 +241,10 @@ impl Explicit {
             .collect()
     }
 
+    /// Tries to prove or disprove the existence of a solution in the block
+    /// and if it is unsuccessful, returns pixels that possibly contains a solution.
+    ///
+    /// Precondition: the block is a subpixel.
     fn process_subpixel_block(&mut self, b: &Block) -> Vec<PixelRegion> {
         let x_up = {
             let u_up = self.block_to_region(b).subpixel_outer(b);
@@ -418,8 +426,9 @@ impl Explicit {
         }
     }
 
-    fn im_intervals(&self, y: &TupperIntervalSet) -> Vec<Interval> {
-        y.iter()
+    /// Returns enclosures of `y` in image coordinates.
+    fn im_intervals(&self, ys: &TupperIntervalSet) -> Vec<Interval> {
+        ys.iter()
             .map(|y| {
                 InexactRegion::new(
                     Interval::ENTIRE,
@@ -442,10 +451,11 @@ impl Explicit {
         }
     }
 
+    /// Returns the smallest pixel-aligned interval that contains `x` in its interior.
     fn outer_pixels(x: Interval) -> Interval {
         const TINY: Interval = const_interval!(-5e-324, 5e-324);
-        let x1 = x + TINY;
-        interval!(x1.inf().floor(), x1.sup().ceil()).unwrap()
+        let x = x + TINY;
+        interval!(x.inf().floor(), x.sup().ceil()).unwrap()
     }
 
     /// For the pixel-aligned region,

--- a/rust/src/graph/explicit.rs
+++ b/rust/src/graph/explicit.rs
@@ -499,7 +499,9 @@ impl Graph for Explicit {
                 .copied()
                 .zip(self.last_queued_blocks.pixels().copied())
                 .filter(|&(s, bi)| {
-                    s == PixelState::True || (bi as usize) < self.block_queue.begin_index()
+                    s == PixelState::True
+                        || s == PixelState::Uncertain
+                            && (bi as usize) < self.block_queue.begin_index()
                 })
                 .count(),
             eval_count: self.rel.eval_count(),

--- a/rust/src/graph/explicit.rs
+++ b/rust/src/graph/explicit.rs
@@ -308,8 +308,8 @@ impl Explicit {
                 if y1.precedes(y2) {
                     py12 = Self::outer_pixels(
                         InexactRegion::new(
-                            point_interval(px.inf()),
-                            point_interval(px.sup()),
+                            const_interval!(0.0, 0.0),
+                            const_interval!(1.0, 1.0),
                             y1,
                             y2,
                         )
@@ -336,10 +336,11 @@ impl Explicit {
             let x = simple_fraction(x_dn);
             let px = {
                 let x = point_interval(x);
-                let im_x = InexactRegion::new(x, x, Interval::ENTIRE, Interval::ENTIRE)
-                    .transform(&self.real_to_im_x)
-                    .outer()
-                    .x();
+                let im_x =
+                    InexactRegion::new(x, x, const_interval!(0.0, 0.0), const_interval!(1.0, 1.0))
+                        .transform(&self.real_to_im_x)
+                        .outer()
+                        .x();
                 if im_x.is_singleton() || Self::outer_pixels(im_x).wid() == 1.0 {
                     Some(Self::outer_pixels(im_x))
                 } else {
@@ -379,14 +380,12 @@ impl Explicit {
     /// Returns the region that corresponds to a subpixel block `b`.
     fn block_to_region(&self, b: &Block) -> InexactRegion {
         let pw = b.widthf();
-        let ph = b.heightf();
         let px = b.x as f64 * pw;
-        let py = b.y as f64 * ph;
         InexactRegion::new(
             point_interval(px),
             point_interval(px + pw),
-            point_interval(py),
-            point_interval(py + ph),
+            const_interval!(0.0, 0.0),
+            const_interval!(1.0, 1.0),
         )
         .transform(&self.im_to_real_x)
     }
@@ -394,14 +393,12 @@ impl Explicit {
     /// Returns the region that corresponds to a pixel or superpixel block `b`.
     fn block_to_region_clipped(&self, b: &Block) -> InexactRegion {
         let pw = b.widthf();
-        let ph = b.heightf();
         let px = b.x as f64 * pw;
-        let py = b.y as f64 * ph;
         InexactRegion::new(
             point_interval(px),
             point_interval((px + pw).min(self.im_width() as f64)),
-            point_interval(py),
-            point_interval((py + ph).min(self.im_height() as f64)),
+            const_interval!(0.0, 0.0),
+            const_interval!(1.0, 1.0),
         )
         .transform(&self.im_to_real_x)
     }
@@ -418,21 +415,13 @@ impl Explicit {
         rel.eval_explicit(point_interval(x), cache)
     }
 
-    fn im_height(&self) -> u32 {
-        if self.transpose {
-            self.im.width()
-        } else {
-            self.im.height()
-        }
-    }
-
     /// Returns enclosures of `y` in image coordinates.
     fn im_intervals(&self, ys: &TupperIntervalSet) -> Vec<Interval> {
         ys.iter()
             .map(|y| {
                 InexactRegion::new(
-                    Interval::ENTIRE,
-                    Interval::ENTIRE,
+                    const_interval!(0.0, 0.0),
+                    const_interval!(1.0, 1.0),
                     point_interval_possibly_infinite(y.x.inf()),
                     point_interval_possibly_infinite(y.x.sup()),
                 )

--- a/rust/src/graph/explicit.rs
+++ b/rust/src/graph/explicit.rs
@@ -23,7 +23,7 @@ use std::{
 pub struct Explicit {
     rel: Relation,
     forms: Vec<StaticForm>,
-    relation_type: RelationType,
+    _relation_type: RelationType,
     im: Image<PixelState>,
     last_queued_blocks: Image<QueuedBlockIndex>,
     block_queue: BlockQueue,
@@ -58,7 +58,7 @@ impl Explicit {
         let mut g = Self {
             rel,
             forms,
-            relation_type,
+            _relation_type: relation_type,
             im: Image::new(im_width, im_height),
             last_queued_blocks: Image::new(im_width, im_height),
             block_queue: BlockQueue::new(BlockQueueOptions {
@@ -179,7 +179,7 @@ impl Explicit {
 
     fn process_block(&mut self, b: &Block) -> Vec<PixelRegion> {
         let x = {
-            let u_up = self.block_to_region_clipped(&b).outer();
+            let u_up = self.block_to_region_clipped(b).outer();
             u_up.x()
         };
         let (ys, cond) = Self::eval_on_interval(&mut self.rel, x);
@@ -227,7 +227,7 @@ impl Explicit {
 
     fn process_subpixel_block(&mut self, b: &Block) -> Vec<PixelRegion> {
         let x_up = {
-            let u_up = self.block_to_region(&b).subpixel_outer(b);
+            let u_up = self.block_to_region(b).subpixel_outer(b);
             u_up.x()
         };
         let x_dn = {
@@ -493,10 +493,10 @@ impl Explicit {
     ///
     /// Precondition: `b.subdivide_on_xy()` is `true`.
     fn subdivide_on_x(&self, sub_bs: &mut Vec<Block>, b: &Block) {
+        let x0 = 2 * b.x;
+        let x1 = x0 + 1;
+        let kx = b.kx - 1;
         if b.is_superpixel() {
-            let x0 = 2 * b.x;
-            let x1 = x0 + 1;
-            let kx = b.kx - 1;
             let b0 = Block::new(x0, 0, kx, 0, b.n_theta, b.t);
             let b0_width = b0.width();
             sub_bs.push(b0);
@@ -504,10 +504,6 @@ impl Explicit {
                 sub_bs.push(Block::new(x1, 0, kx, 0, b.n_theta, b.t));
             }
         } else {
-            // Subdivide only horizontally.
-            let x0 = 2 * b.x;
-            let x1 = x0 + 1;
-            let kx = b.kx - 1;
             sub_bs.push(Block::new(x0, 0, kx, 0, b.n_theta, b.t));
             sub_bs.push(Block::new(x1, 0, kx, 0, b.n_theta, b.t));
         }

--- a/rust/src/graph/explicit.rs
+++ b/rust/src/graph/explicit.rs
@@ -130,8 +130,8 @@ impl Explicit {
                 } else {
                     for ps in incomplete_pixels {
                         for p in &ps {
-                            if self.im.get(p) == PixelState::Uncertain {
-                                *self.im.get_mut(p) = PixelState::UncertainNeverFalse;
+                            if self.im[p] == PixelState::Uncertain {
+                                self.im[p] = PixelState::UncertainNeverFalse;
                             }
                         }
                     }
@@ -212,7 +212,7 @@ impl Explicit {
             if py.wid() == 1.0 {
                 // y is interior to a single row.
                 for p in &self.pixels_in_image(&Region::new(px, py)) {
-                    *self.im.get_mut(p) = PixelState::True;
+                    self.im[p] = PixelState::True;
                 }
                 return incomplete_pixels;
             }
@@ -222,7 +222,7 @@ impl Explicit {
 
         for py in pys {
             let ps = self.pixels_in_image(&Region::new(px, py));
-            if ps.iter().all(|p| self.im.get(p) == PixelState::True) {
+            if ps.iter().all(|p| self.im[p] == PixelState::True) {
                 // The case where `ps` is empty goes here.
                 continue;
             } else {
@@ -272,7 +272,7 @@ impl Explicit {
             if py.wid() == 1.0 {
                 // y is interior to a single row.
                 for p in &self.pixels_in_image(&Region::new(px, py)) {
-                    *self.im.get_mut(p) = PixelState::True;
+                    self.im[p] = PixelState::True;
                 }
                 return incomplete_pixels;
             } else if dec >= Decoration::Dac && !x_dn.is_empty() {
@@ -309,7 +309,7 @@ impl Explicit {
                 }
 
                 for p in &self.pixels_in_image(&Region::new(px, py12)) {
-                    *self.im.get_mut(p) = PixelState::True;
+                    self.im[p] = PixelState::True;
                 }
 
                 if py12 == py {
@@ -352,7 +352,7 @@ impl Explicit {
                     let py = Self::outer_pixels(im_y);
                     if im_y.is_singleton() || py.wid() == 1.0 {
                         for p in &self.pixels_in_image(&Region::new(px, py)) {
-                            *self.im.get_mut(p) = PixelState::True;
+                            self.im[p] = PixelState::True;
                         }
                     }
                 }
@@ -361,7 +361,7 @@ impl Explicit {
 
         for py in pys {
             let ps = self.pixels_in_image(&Region::new(px, py));
-            if ps.iter().all(|p| self.im.get(p) == PixelState::True) {
+            if ps.iter().all(|p| self.im[p] == PixelState::True) {
                 // The case where `ps` is empty goes here.
                 continue;
             } else {
@@ -425,7 +425,7 @@ impl Explicit {
     ) -> Result<(), GraphingError> {
         if let Ok(block_index) = QueuedBlockIndex::try_from(block_index) {
             for p in r.iter() {
-                *self.last_queued_blocks.get_mut(p) = block_index;
+                self.last_queued_blocks[p] = block_index;
             }
             Ok(())
         } else {

--- a/rust/src/graph/explicit.rs
+++ b/rust/src/graph/explicit.rs
@@ -1,0 +1,516 @@
+use crate::{
+    block::{Block, BlockQueue, BlockQueueOptions},
+    eval_result::EvalResult,
+    graph::{
+        Graph, GraphingError, GraphingErrorKind, GraphingStatistics, PixelState, QueuedBlockIndex,
+    },
+    image::{Image, PixelIndex, PixelRegion},
+    interval_set::{DecSignSet, SignSet, TupperIntervalSet},
+    ops::StaticForm,
+    region::{InexactRegion, Region, Transform},
+    relation::{EvalFunctionCache, Relation, RelationType},
+};
+use image::{imageops, ImageBuffer, Pixel};
+use inari::{const_interval, interval, Decoration, Interval};
+use std::{
+    convert::TryFrom,
+    mem::swap,
+    ops::{Deref, DerefMut},
+    time::{Duration, Instant},
+};
+
+/// The graphing algorithm for explicit relations.
+pub struct Explicit {
+    rel: Relation,
+    forms: Vec<StaticForm>,
+    relation_type: RelationType,
+    im: Image<PixelState>,
+    last_queued_blocks: Image<QueuedBlockIndex>,
+    block_queue: BlockQueue,
+    im_region: Region,
+    transform: Transform,
+    inv_transform: Transform,
+    stats: GraphingStatistics,
+    mem_limit: usize,
+    cache: EvalFunctionCache,
+}
+
+impl Explicit {
+    pub fn new(
+        rel: Relation,
+        region: InexactRegion,
+        im_width: u32,
+        im_height: u32,
+        mem_limit: usize,
+    ) -> Self {
+        const ONE: Interval = const_interval!(1.0, 1.0);
+
+        assert!(matches!(
+            rel.relation_type(),
+            RelationType::ExplicitFunctionOfX | RelationType::ExplicitFunctionOfY
+        ));
+
+        let forms = rel.forms().clone();
+        let relation_type = rel.relation_type();
+        let im_width_interval = Self::point_interval(im_width as f64);
+        let im_height_interval = Self::point_interval(im_height as f64);
+        let mut g = Self {
+            rel,
+            forms,
+            relation_type,
+            im: Image::new(im_width, im_height),
+            last_queued_blocks: Image::new(im_width, im_height),
+            block_queue: BlockQueue::new(BlockQueueOptions {
+                store_xy: true,
+                ..Default::default()
+            }),
+            im_region: Region::new(
+                interval!(0.0, im_width as f64).unwrap(),
+                interval!(0.0, im_height as f64).unwrap(),
+            ),
+            transform: Transform::with_predivision_factors(
+                (region.width(), im_width_interval),
+                region.left(),
+                (ONE, ONE),
+                const_interval!(0.0, 0.0),
+            ),
+            inv_transform: {
+                Transform::with_predivision_factors(
+                    (ONE, ONE),
+                    const_interval!(0.0, 0.0),
+                    (im_height_interval, region.height()),
+                    -im_height_interval * (region.bottom() / region.height()),
+                )
+            },
+            stats: GraphingStatistics {
+                pixels: im_width as usize * im_height as usize,
+                pixels_proven: 0,
+                eval_count: 0,
+                time_elapsed: Duration::ZERO,
+            },
+            mem_limit,
+            cache: EvalFunctionCache::new(),
+        };
+
+        let kx = (im_width as f64).log2().ceil() as i8;
+        let b = Block::new(0, 0, kx, 0, Interval::ENTIRE, Interval::ENTIRE);
+        g.block_queue.push_back(b);
+
+        g
+    }
+
+    fn refine_impl(&mut self, duration: Duration, now: &Instant) -> Result<bool, GraphingError> {
+        let mut sub_bs = vec![];
+        while let Some(b) = self.block_queue.pop_front() {
+            let incomplete_pixels = if !b.is_subpixel() {
+                self.process_block(&b)
+            } else {
+                self.process_subpixel_block(&b)
+            };
+
+            if !incomplete_pixels.is_empty() {
+                if b.is_xy_subdivisible() {
+                    self.subdivide_on_x(&mut sub_bs, &b);
+                    for sub_b in sub_bs.drain(..) {
+                        self.block_queue.push_back(sub_b);
+                    }
+                    let last_index = self.block_queue.end_index() - 1;
+                    for ps in incomplete_pixels {
+                        self.set_last_queued_block(&ps, last_index)?;
+                    }
+                } else {
+                    for ps in incomplete_pixels {
+                        for p in &ps {
+                            if self.im.get(p) == PixelState::Uncertain {
+                                *self.im.get_mut(p) = PixelState::UncertainNeverFalse;
+                            }
+                        }
+                    }
+                }
+            }
+
+            let mut clear_cache_and_retry = true;
+            while self.im.size_in_heap()
+                + self.last_queued_blocks.size_in_heap()
+                + self.block_queue.size_in_heap()
+                + self.cache.size_in_heap()
+                > self.mem_limit
+            {
+                if clear_cache_and_retry {
+                    self.cache.clear();
+                    clear_cache_and_retry = false;
+                } else {
+                    return Err(GraphingError {
+                        kind: GraphingErrorKind::ReachedMemLimit,
+                    });
+                }
+            }
+
+            if now.elapsed() > duration {
+                break;
+            }
+        }
+
+        if self.block_queue.is_empty() {
+            if self
+                .im
+                .pixels()
+                .any(|&s| s == PixelState::UncertainNeverFalse)
+            {
+                Err(GraphingError {
+                    kind: GraphingErrorKind::ReachedSubdivisionLimit,
+                })
+            } else {
+                Ok(true)
+            }
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn process_block(&mut self, b: &Block) -> Vec<PixelRegion> {
+        let x = {
+            let u_up = self.block_to_region_clipped(&b).outer();
+            u_up.x()
+        };
+        let pixel_x = {
+            let begin = b.pixel_index().x;
+            let end = (begin + b.width()).min(self.im.width());
+            interval!(begin as f64, end as f64).unwrap()
+        };
+        let (y, cond) = Self::eval_on_interval(&mut self.rel, x);
+        let rs = self
+            .regions(pixel_x, &y)
+            .iter()
+            .into_iter()
+            .map(|r| Self::outer_pixels(r))
+            .collect::<Vec<_>>();
+
+        let cond_is_true = cond
+            .map(|DecSignSet(ss, d)| ss == SignSet::ZERO && d >= Decoration::Def)
+            .eval(&self.forms[..]);
+        let cond_is_false = !cond
+            .map(|DecSignSet(ss, _)| ss.contains(SignSet::ZERO))
+            .eval(&self.forms[..]);
+
+        let mut incomplete_pixels = vec![];
+
+        let dec = y.decoration();
+        if dec >= Decoration::Def && cond_is_true {
+            let r = rs.iter().fold(Region::EMPTY, |acc, r| acc.convex_hull(r));
+
+            let y = r.y();
+            if y.wid() == 1.0 {
+                // y is interior to a single row.
+                for p in &self.pixels_in_image(&r) {
+                    *self.im.get_mut(p) = PixelState::True;
+                }
+                return incomplete_pixels;
+            }
+        } else if cond_is_false {
+            return incomplete_pixels;
+        }
+
+        for r in rs {
+            let ps = self.pixels_in_image(&r);
+            if ps.iter().all(|p| self.im.get(p) == PixelState::True) {
+                // The case where `ps` is empty goes here.
+                continue;
+            } else {
+                incomplete_pixels.push(ps)
+            }
+        }
+
+        incomplete_pixels
+    }
+
+    fn process_subpixel_block(&mut self, b: &Block) -> Vec<PixelRegion> {
+        let x_up = {
+            let u_up = self.block_to_region(&b).subpixel_outer(b);
+            u_up.x()
+        };
+        let x_dn = {
+            let p_dn = self.block_to_region(&b.pixel_block()).inner();
+            x_up.intersection(p_dn.x())
+        };
+        let pixel_x = {
+            let begin = b.pixel_index().x;
+            let end = begin + 1;
+            interval!(begin as f64, end as f64).unwrap()
+        };
+        let (y, cond) = Self::eval_on_interval(&mut self.rel, x_up);
+        let rs = self
+            .regions(pixel_x, &y)
+            .iter()
+            .into_iter()
+            .map(|r| Self::outer_pixels(r))
+            .collect::<Vec<_>>();
+
+        let cond_is_true = cond
+            .map(|DecSignSet(ss, d)| ss == SignSet::ZERO && d >= Decoration::Def)
+            .eval(&self.forms[..]);
+        let cond_is_false = !cond
+            .map(|DecSignSet(ss, _)| ss.contains(SignSet::ZERO))
+            .eval(&self.forms[..]);
+
+        let mut incomplete_pixels = vec![];
+
+        let dec = y.decoration();
+        if dec >= Decoration::Def && cond_is_true {
+            let r = rs.iter().fold(Region::EMPTY, |acc, r| acc.convex_hull(r));
+
+            let y = r.y();
+            if y.wid() == 1.0 {
+                // y is interior to a single row.
+                for p in &self.pixels_in_image(&r) {
+                    *self.im.get_mut(p) = PixelState::True;
+                }
+                return incomplete_pixels;
+            } else if dec >= Decoration::Dac && !x_dn.is_empty() {
+                assert_eq!(rs.len(), 1);
+                let mut y1 = {
+                    let (y, _) =
+                        Self::eval_on_point(&mut self.rel, x_dn.inf(), Some(&mut self.cache));
+                    assert_eq!(y.len(), 1);
+                    y.iter().next().unwrap().x
+                };
+                let mut y2 = {
+                    let (y, _) =
+                        Self::eval_on_point(&mut self.rel, x_dn.sup(), Some(&mut self.cache));
+                    assert_eq!(y.len(), 1);
+                    y.iter().next().unwrap().x
+                };
+
+                let mut r12 = Region::EMPTY;
+                if y2.precedes(y1) {
+                    swap(&mut y1, &mut y2);
+                }
+                if y1.precedes(y2) {
+                    let r = InexactRegion::new(
+                        Self::point_interval(pixel_x.inf()),
+                        Self::point_interval(pixel_x.sup()),
+                        y1,
+                        y2,
+                    )
+                    .transform(&self.inv_transform)
+                    .inner();
+                    if !r.is_empty() {
+                        r12 = Self::outer_pixels(&r);
+                    }
+                }
+
+                for p in &self.pixels_in_image(&r12) {
+                    *self.im.get_mut(p) = PixelState::True;
+                }
+
+                if r12 == r {
+                    return incomplete_pixels;
+                }
+            }
+        } else if cond_is_false {
+            return incomplete_pixels;
+        }
+
+        for r in rs {
+            let ps = self.pixels_in_image(&r);
+            if ps.iter().all(|p| self.im.get(p) == PixelState::True) {
+                // The case where `ps` is empty goes here.
+                continue;
+            } else {
+                incomplete_pixels.push(ps)
+            }
+        }
+
+        incomplete_pixels
+    }
+
+    /// Returns the region that corresponds to a subpixel block `b`.
+    fn block_to_region(&self, b: &Block) -> InexactRegion {
+        let pw = b.widthf();
+        let ph = b.heightf();
+        let px = b.x as f64 * pw;
+        let py = b.y as f64 * ph;
+        InexactRegion::new(
+            Self::point_interval(px),
+            Self::point_interval(px + pw),
+            Self::point_interval(py),
+            Self::point_interval(py + ph),
+        )
+        .transform(&self.transform)
+    }
+
+    /// Returns the region that corresponds to a pixel or superpixel block `b`.
+    fn block_to_region_clipped(&self, b: &Block) -> InexactRegion {
+        let pw = b.widthf();
+        let ph = b.heightf();
+        let px = b.x as f64 * pw;
+        let py = b.y as f64 * ph;
+        InexactRegion::new(
+            Self::point_interval(px),
+            Self::point_interval((px + pw).min(self.im.width() as f64)),
+            Self::point_interval(py),
+            Self::point_interval((py + ph).min(self.im.height() as f64)),
+        )
+        .transform(&self.transform)
+    }
+
+    fn regions(&self, x: Interval, y: &TupperIntervalSet) -> Vec<Region> {
+        y.iter()
+            .map(|y| {
+                InexactRegion::new(
+                    Self::point_interval(x.inf()),
+                    Self::point_interval(x.sup()),
+                    Self::point_interval_possibly_infinite(y.x.inf()),
+                    Self::point_interval_possibly_infinite(y.x.sup()),
+                )
+                .transform(&self.inv_transform)
+                .outer()
+            })
+            .collect::<Vec<_>>()
+    }
+
+    fn set_last_queued_block(
+        &mut self,
+        r: &PixelRegion,
+        block_index: usize,
+    ) -> Result<(), GraphingError> {
+        if let Ok(block_index) = QueuedBlockIndex::try_from(block_index) {
+            for p in r.iter() {
+                *self.last_queued_blocks.get_mut(p) = block_index;
+            }
+            Ok(())
+        } else {
+            Err(GraphingError {
+                kind: GraphingErrorKind::BlockIndexOverflow,
+            })
+        }
+    }
+
+    fn eval_on_point(
+        rel: &mut Relation,
+        x: f64,
+        cache: Option<&mut EvalFunctionCache>,
+    ) -> (TupperIntervalSet, EvalResult) {
+        rel.eval_function_of_x(Self::point_interval(x), cache)
+    }
+
+    fn eval_on_interval(rel: &mut Relation, x: Interval) -> (TupperIntervalSet, EvalResult) {
+        rel.eval_function_of_x(x, None)
+    }
+
+    fn outer_pixels(r: &Region) -> Region {
+        const TINY: Interval = const_interval!(-5e-324, 5e-324);
+        let r1 = r.y() + TINY;
+        Region::new(r.x(), interval!(r1.inf().floor(), r1.sup().ceil()).unwrap())
+    }
+
+    /// For the pixel-aligned region,
+    /// returns the pixels in the region that are contained in the image.
+    fn pixels_in_image(&self, r: &Region) -> PixelRegion {
+        let r = r.intersection(&self.im_region);
+        if r.is_empty() {
+            PixelRegion::EMPTY
+        } else {
+            // If `r` is degenerate, the result is `PixelRegion::EMPTY`.
+            let x = r.x();
+            let y = r.y();
+            PixelRegion::new(
+                PixelIndex::new(x.inf() as u32, y.inf() as u32),
+                PixelIndex::new(x.sup() as u32, y.sup() as u32),
+            )
+        }
+    }
+
+    fn point_interval(x: f64) -> Interval {
+        interval!(x, x).unwrap()
+    }
+
+    fn point_interval_possibly_infinite(x: f64) -> Interval {
+        if x == f64::NEG_INFINITY {
+            const_interval!(f64::NEG_INFINITY, f64::MIN)
+        } else if x == f64::INFINITY {
+            const_interval!(f64::MAX, f64::INFINITY)
+        } else {
+            Self::point_interval(x)
+        }
+    }
+
+    /// Subdivides the block and appends the sub-blocks to `sub_bs`.
+    /// Two sub-blocks are created at most.
+    ///
+    /// Precondition: `b.subdivide_on_xy()` is `true`.
+    fn subdivide_on_x(&self, sub_bs: &mut Vec<Block>, b: &Block) {
+        if b.is_superpixel() {
+            let x0 = 2 * b.x;
+            let x1 = x0 + 1;
+            let kx = b.kx - 1;
+            let b0 = Block::new(x0, 0, kx, 0, b.n_theta, b.t);
+            let b0_width = b0.width();
+            sub_bs.push(b0);
+            if x1 * b0_width < self.im.width() {
+                sub_bs.push(Block::new(x1, 0, kx, 0, b.n_theta, b.t));
+            }
+        } else {
+            // Subdivide only horizontally.
+            let x0 = 2 * b.x;
+            let x1 = x0 + 1;
+            let kx = b.kx - 1;
+            sub_bs.push(Block::new(x0, 0, kx, 0, b.n_theta, b.t));
+            sub_bs.push(Block::new(x1, 0, kx, 0, b.n_theta, b.t));
+        }
+    }
+}
+
+impl Graph for Explicit {
+    fn get_image<P, Container>(
+        &self,
+        im: &mut ImageBuffer<P, Container>,
+        true_color: P,
+        uncertain_color: P,
+        false_color: P,
+    ) where
+        P: Pixel + 'static,
+        Container: Deref<Target = [P::Subpixel]> + DerefMut,
+    {
+        assert!(im.width() == self.im.width() && im.height() == self.im.height());
+        for ((s, bi), dst) in self
+            .im
+            .pixels()
+            .copied()
+            .zip(self.last_queued_blocks.pixels().copied())
+            .zip(im.pixels_mut())
+        {
+            *dst = match s {
+                PixelState::True => true_color,
+                PixelState::Uncertain if (bi as usize) < self.block_queue.begin_index() => {
+                    false_color
+                }
+                _ => uncertain_color,
+            }
+        }
+        imageops::flip_vertical_in_place(im);
+    }
+
+    fn get_statistics(&self) -> GraphingStatistics {
+        GraphingStatistics {
+            pixels_proven: self
+                .im
+                .pixels()
+                .copied()
+                .zip(self.last_queued_blocks.pixels().copied())
+                .filter(|&(s, bi)| {
+                    s == PixelState::True || (bi as usize) < self.block_queue.begin_index()
+                })
+                .count(),
+            eval_count: self.rel.eval_count(),
+            ..self.stats
+        }
+    }
+
+    fn refine(&mut self, duration: Duration) -> Result<bool, GraphingError> {
+        let now = Instant::now();
+        let result = self.refine_impl(duration, &now);
+        self.stats.time_elapsed += now.elapsed();
+        result
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::float_cmp)]
 #![feature(box_patterns, box_syntax, once_cell)]
 
-pub use graph::{Graph, GraphingStatistics, Implicit, InexactRegion, Parametric};
+pub use graph::{Explicit, Graph, GraphingStatistics, Implicit, InexactRegion, Parametric};
 pub use relation::{Relation, RelationType};
 
 #[cfg(feature = "arb")]

--- a/rust/src/relation.rs
+++ b/rust/src/relation.rs
@@ -139,7 +139,7 @@ impl EvalExplicitCache {
             * (size_of::<u64>() + size_of::<Interval>() + size_of::<EvalParametricResult>());
     }
 
-    /// Returns the approximate size allocated by the [`EvalFunctionCache`] in bytes.
+    /// Returns the approximate size allocated by the [`EvalExplicitCache`] in bytes.
     pub fn size_in_heap(&self) -> usize {
         self.size_of_ct + self.size_of_values_in_heap
     }

--- a/rust/src/relation.rs
+++ b/rust/src/relation.rs
@@ -208,6 +208,17 @@ pub struct RelationArgs {
     pub t: Interval,
 }
 
+impl Default for RelationArgs {
+    fn default() -> Self {
+        Self {
+            x: Interval::ENTIRE,
+            y: Interval::ENTIRE,
+            n_theta: Interval::ENTIRE,
+            t: Interval::ENTIRE,
+        }
+    }
+}
+
 /// A mathematical relation whose graph is to be plotted.
 #[derive(Clone, Debug)]
 pub struct Relation {
@@ -419,9 +430,7 @@ impl Relation {
                 let p = self.eval(
                     &RelationArgs {
                         x,
-                        y: Interval::ENTIRE,
-                        n_theta: Interval::ENTIRE,
-                        t: Interval::ENTIRE,
+                        ..Default::default()
                     },
                     None,
                 );
@@ -431,10 +440,8 @@ impl Relation {
             RelationType::ExplicitFunctionOfY => {
                 let p = self.eval(
                     &RelationArgs {
-                        x: Interval::ENTIRE,
                         y: x,
-                        n_theta: Interval::ENTIRE,
-                        t: Interval::ENTIRE,
+                        ..Default::default()
                     },
                     None,
                 );
@@ -448,10 +455,8 @@ impl Relation {
     fn eval_parametric_without_cache(&mut self, t: Interval) -> EvalParametricResult {
         let p = self.eval(
             &RelationArgs {
-                x: Interval::ENTIRE,
-                y: Interval::ENTIRE,
-                n_theta: Interval::ENTIRE,
                 t,
+                ..Default::default()
             },
             None,
         );

--- a/rust/src/relation.rs
+++ b/rust/src/relation.rs
@@ -24,7 +24,7 @@ pub enum EvalCacheLevel {
     Full,
 }
 
-/// A cache for evaluation results of an implicit relation.
+/// A cache for memoizing evaluation of an implicit relation.
 pub struct EvalCache {
     level: EvalCacheLevel,
     cx: HashMap<Interval, Vec<TupperIntervalSet>>,
@@ -113,6 +113,7 @@ impl EvalCache {
 
 type EvalExplicitResult = (TupperIntervalSet, EvalResult);
 
+/// A cache for memoizing evaluation of an explicit relation.
 #[derive(Default)]
 pub struct EvalExplicitCache {
     ct: HashMap<Interval, EvalExplicitResult>,
@@ -147,7 +148,7 @@ impl EvalExplicitCache {
 
 type EvalParametricResult = (TupperIntervalSet, TupperIntervalSet, EvalResult);
 
-/// A cache for evaluation results of a parametric relation.
+/// A cache for memoizing evaluation of a parametric relation.
 #[derive(Default)]
 pub struct EvalParametricCache {
     ct: HashMap<Interval, EvalParametricResult>,
@@ -180,7 +181,7 @@ impl EvalParametricCache {
     }
 }
 
-/// The type of a [`Relation`], which should be used when choosing the optimal graphing algorithm.
+/// The type of a [`Relation`], which decides the graphing algorithm to be used.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RelationType {
     /// A relation of the form y = f(x) ∧ P(x), where P(x) is an optional constraint on x.


### PR DESCRIPTION
## Tasks

- [x] Investigate differences between results produced by `Implicit` and `Explicit`
  - \[Fixed\] `floor(x)`, `sgn(x)`, `gcd(x, 1)`
  - \[Fixed\] `Si(1/x)` - I guess this is because Arb functions can return a wider interval for a narrower (refined) input
- [x] Handle `RelationType::ExplicitFunctionOfY`
  - Swap the axes on:
    - construction of the images
    - evaluation
    - indexing into the images
- [x] Extract the types/functions commonly used by graphing algorithms to `graph/common.rs`

To be done in separate PRs:

- Handle inequalities and negation
- Subdivide x or y separately in `Implicit`
- Remove `RelationType::FunctionOfX`/`FunctionOfY`
