### PR TITLE
Rename `PixelRegion` to `PixelRange`

### DIFF
--- a/rust/src/graph/explicit.rs
+++ b/rust/src/graph/explicit.rs
@@ -8,7 +8,7 @@ use crate::{
         },
         Graph, GraphingError, GraphingErrorKind, GraphingStatistics,
     },
-    image::{Image, PixelIndex, PixelRegion},
+    image::{Image, PixelIndex, PixelRange},
     interval_set::{DecSignSet, SignSet, TupperIntervalSet},
     ops::StaticForm,
     region::{InexactRegion, Region, Transform},
@@ -170,10 +170,10 @@ impl Explicit {
     }
 
     /// Tries to prove or disprove the existence of a solution in the block
-    /// and if it is unsuccessful, returns pixels that possibly contains a solution.
+    /// and if it is unsuccessful, returns pixels that possibly contain solutions.
     ///
     /// Precondition: the block is either a pixel or a superpixel.
-    fn process_block(&mut self, b: &Block) -> Vec<PixelRegion> {
+    fn process_block(&mut self, b: &Block) -> Vec<PixelRange> {
         let x = {
             let u_up = self.block_to_region_clipped(b).outer();
             u_up.x()
@@ -221,10 +221,10 @@ impl Explicit {
     }
 
     /// Tries to prove or disprove the existence of a solution in the block
-    /// and if it is unsuccessful, returns pixels that possibly contains a solution.
+    /// and if it is unsuccessful, returns pixels that possibly contain solutions.
     ///
     /// Precondition: the block is a subpixel.
-    fn process_subpixel_block(&mut self, b: &Block) -> Vec<PixelRegion> {
+    fn process_subpixel_block(&mut self, b: &Block) -> Vec<PixelRange> {
         let x_up = {
             let u_up = self.block_to_region(b).subpixel_outer(b);
             u_up.x()
@@ -403,7 +403,7 @@ impl Explicit {
         }
     }
 
-    fn is_any_pixel_uncertain(&self, pixels: &[PixelRegion], parent_block_index: usize) -> bool {
+    fn is_any_pixel_uncertain(&self, pixels: &[PixelRange], parent_block_index: usize) -> bool {
         pixels.iter().flatten().any(|p| {
             let s = self.im[p];
             let bi = self.last_queued_blocks[p];
@@ -426,18 +426,18 @@ impl Explicit {
     /// For the pixel-aligned region, returns the pixels in the region that are contained in the image.
     ///
     /// If [`self.transpose`] is `true`, the x and y components of the result are swapped.
-    fn pixels_in_image(&self, r: &Region) -> PixelRegion {
+    fn pixels_in_image(&self, r: &Region) -> PixelRange {
         let r = r.intersection(&self.im_region);
         if r.is_empty() {
-            PixelRegion::EMPTY
+            PixelRange::EMPTY
         } else {
-            // If `r` is degenerate, the result is `PixelRegion::EMPTY`.
+            // If `r` is degenerate, the result is `PixelRange::EMPTY`.
             let mut x = r.x();
             let mut y = r.y();
             if self.transpose {
                 swap(&mut x, &mut y);
             }
-            PixelRegion::new(
+            PixelRange::new(
                 PixelIndex::new(x.inf() as u32, y.inf() as u32),
                 PixelIndex::new(x.sup() as u32, y.sup() as u32),
             )
@@ -446,7 +446,7 @@ impl Explicit {
 
     fn set_last_queued_block(
         &mut self,
-        pixels: &[PixelRegion],
+        pixels: &[PixelRange],
         block_index: usize,
         parent_block_index: usize,
     ) -> Result<(), GraphingError> {
@@ -467,7 +467,7 @@ impl Explicit {
         }
     }
 
-    fn set_uncertain_never_false(&mut self, pixels: &[PixelRegion], parent_block_index: usize) {
+    fn set_uncertain_never_false(&mut self, pixels: &[PixelRange], parent_block_index: usize) {
         for p in pixels.iter().flatten() {
             if self.im[p] == PixelState::Uncertain
                 // Check if the pixel is not already revealed to be false.

--- a/rust/src/graph/implicit.rs
+++ b/rust/src/graph/implicit.rs
@@ -5,7 +5,7 @@ use crate::{
         common::{point_interval, simple_fraction, PixelState, QueuedBlockIndex},
         Graph, GraphingError, GraphingErrorKind, GraphingStatistics,
     },
-    image::{Image, PixelIndex, PixelRegion},
+    image::{Image, PixelIndex, PixelRange},
     interval_set::{DecSignSet, SignSet},
     ops::StaticForm,
     region::{InexactRegion, Region, Transform},
@@ -267,7 +267,7 @@ impl Implicit {
                         (begin.x + b.width()).min(self.im.width()),
                         (begin.y + b.height()).min(self.im.height()),
                     );
-                    PixelRegion::new(begin, end)
+                    PixelRange::new(begin, end)
                 };
 
                 for p in pixels.iter() {
@@ -301,7 +301,7 @@ impl Implicit {
                 (begin.x + b.width()).min(self.im.width()),
                 (begin.y + b.height()).min(self.im.height()),
             );
-            PixelRegion::new(begin, end)
+            PixelRange::new(begin, end)
         };
 
         if pixels.iter().all(|p| self.im[p] == PixelState::True) {

--- a/rust/src/image.rs
+++ b/rust/src/image.rs
@@ -85,18 +85,18 @@ impl PixelIndex {
 
 /// A rectangular region of an [`Image`].
 #[derive(Clone, Debug)]
-pub struct PixelRegion {
+pub struct PixelRange {
     begin: PixelIndex,
     end: PixelIndex,
 }
 
-impl PixelRegion {
+impl PixelRange {
     pub const EMPTY: Self = Self {
         begin: PixelIndex { x: 0, y: 0 },
         end: PixelIndex { x: 0, y: 0 },
     };
 
-    /// Creates a new [`PixelRegion`] that spans pixels within
+    /// Creates a new [`PixelRange`] that spans pixels within
     /// `begin.x ≤ x < end.x` and `begin.y ≤ y < end.y`.
     pub fn new(begin: PixelIndex, end: PixelIndex) -> Self {
         assert!(begin.x <= end.x && begin.y <= end.y);
@@ -113,7 +113,7 @@ impl PixelRegion {
     }
 }
 
-impl<'a> IntoIterator for &'a PixelRegion {
+impl<'a> IntoIterator for &'a PixelRange {
     type Item = PixelIndex;
     type IntoIter = PixelIter<'a>;
 
@@ -127,7 +127,7 @@ impl<'a> IntoIterator for &'a PixelRegion {
 
 /// An iterator that iterates over the pixels of an [`Image`].
 pub struct PixelIter<'a> {
-    region: &'a PixelRegion,
+    region: &'a PixelRange,
     p: PixelIndex,
 }
 
@@ -174,20 +174,20 @@ mod tests {
     }
 
     #[test]
-    fn pixel_region() {
-        let r = PixelRegion::new(PixelIndex::new(1, 2), PixelIndex::new(1, 2));
+    fn pixel_range() {
+        let r = PixelRange::new(PixelIndex::new(1, 2), PixelIndex::new(1, 2));
         let mut iter = r.iter();
         assert_eq!(iter.next(), None);
 
-        let r = PixelRegion::new(PixelIndex::new(1, 2), PixelIndex::new(4, 2));
+        let r = PixelRange::new(PixelIndex::new(1, 2), PixelIndex::new(4, 2));
         let mut iter = r.iter();
         assert_eq!(iter.next(), None);
 
-        let r = PixelRegion::new(PixelIndex::new(1, 2), PixelIndex::new(1, 8));
+        let r = PixelRange::new(PixelIndex::new(1, 2), PixelIndex::new(1, 8));
         let mut iter = r.iter();
         assert_eq!(iter.next(), None);
 
-        let r = PixelRegion::new(PixelIndex::new(1, 2), PixelIndex::new(4, 8));
+        let r = PixelRange::new(PixelIndex::new(1, 2), PixelIndex::new(4, 8));
         let mut iter = r.iter();
         for y in 2..8 {
             for x in 1..4 {


### PR DESCRIPTION
Conventionally, the term "range" is used for a set of discrete values.