### PR TITLE
Preliminary work for making graphs look smoother on Retina displays

### DIFF
--- a/rust/src/bin/graph.rs
+++ b/rust/src/bin/graph.rs
@@ -1,10 +1,11 @@
 use clap::{App, Arg, ArgSettings};
 use graphest::{
-    Box2D, Constant, Explicit, Graph, GraphingStatistics, Implicit, Parametric, Relation,
-    RelationType,
+    Box2D, Constant, Explicit, Graph, GraphingStatistics, Image, Implicit, Parametric, PixelIndex,
+    PixelRange, Relation, RelationType, Ternary,
 };
 use image::{GrayAlphaImage, LumaA, Rgb, RgbImage};
 use inari::{const_interval, interval, Interval};
+use itertools::Itertools;
 use std::{ffi::OsString, time::Duration};
 
 fn print_statistics_header() {
@@ -54,6 +55,12 @@ fn main() {
                 .default_values(&["-10", "10", "-10", "10"])
                 .value_names(&["xmin", "xmax", "ymin", "ymax"])
                 .about("Bounds of the region to plot over."),
+        )
+        .arg(
+            Arg::new("dilate")
+                .long("dilate")
+                .setting(ArgSettings::Hidden)
+                .default_value("0"),
         )
         .arg(
             Arg::new("gray-alpha")
@@ -109,6 +116,7 @@ fn main() {
         .iter()
         .map(|s| to_interval(s))
         .collect::<Vec<_>>();
+    let dilation = matches.value_of_t_or_exit::<u32>("dilate");
     let gray_alpha = matches.is_present("gray-alpha");
     let mem_limit = 1024 * 1024 * matches.value_of_t_or_exit::<usize>("mem-limit");
     let output = matches.value_of_os("output").unwrap().to_owned();
@@ -119,47 +127,83 @@ fn main() {
         Err(e) => e.exit(),
     };
 
+    let dilation_kernel = {
+        let diam = 2 * dilation + 1;
+        let rad = dilation + 1;
+        let mut ker = Image::<bool>::new(diam, diam);
+        for ((y, x), p) in (0..diam).cartesian_product(0..diam).zip(ker.pixels_mut()) {
+            *p = y < rad && x < rad;
+        }
+        ker
+    };
+
+    let padded_size = [size[0] + 2 * dilation, size[1] + 2 * dilation];
+
     let opts = PlotOptions {
+        dilation_kernel,
         gray_alpha,
         output,
-        im_width: size[0],
-        im_height: size[1],
+        padded_size,
+        size: [size[0], size[1]],
         timeout,
     };
     let region = Box2D::new(bounds[0], bounds[1], bounds[2], bounds[3]);
 
     match rel.relation_type() {
-        RelationType::Constant => plot(Constant::new(rel, size[0], size[1]), opts),
+        RelationType::Constant => plot(Constant::new(rel, padded_size[0], padded_size[1]), opts),
         RelationType::ExplicitFunctionOfX(_) | RelationType::ExplicitFunctionOfY(_) => plot(
-            Explicit::new(rel, region, size[0], size[1], 0, mem_limit),
+            Explicit::new(
+                rel,
+                region,
+                padded_size[0],
+                padded_size[1],
+                dilation,
+                mem_limit,
+            ),
             opts,
         ),
         RelationType::Parametric => plot(
-            Parametric::new(rel, region, size[0], size[1], 0, mem_limit),
+            Parametric::new(
+                rel,
+                region,
+                padded_size[0],
+                padded_size[1],
+                dilation,
+                mem_limit,
+            ),
             opts,
         ),
         _ => plot(
-            Implicit::new(rel, region, size[0], size[1], 0, mem_limit),
+            Implicit::new(
+                rel,
+                region,
+                padded_size[0],
+                padded_size[1],
+                dilation,
+                mem_limit,
+            ),
             opts,
         ),
     };
 }
 
 struct PlotOptions {
+    dilation_kernel: Image<bool>,
     gray_alpha: bool,
     output: OsString,
-    im_width: u32,
-    im_height: u32,
+    padded_size: [u32; 2],
+    size: [u32; 2],
     timeout: Option<Duration>,
 }
 
 fn plot<G: Graph>(mut g: G, opts: PlotOptions) {
     let mut gray_alpha_im: Option<GrayAlphaImage> = None;
     let mut rgb_im: Option<RgbImage> = None;
+    let mut raw_im = Image::<Ternary>::new(opts.padded_size[0], opts.padded_size[1]);
     if opts.gray_alpha {
-        gray_alpha_im = Some(GrayAlphaImage::new(opts.im_width, opts.im_height));
+        gray_alpha_im = Some(GrayAlphaImage::new(opts.size[0], opts.size[1]));
     } else {
-        rgb_im = Some(RgbImage::new(opts.im_width, opts.im_height));
+        rgb_im = Some(RgbImage::new(opts.size[0], opts.size[1]));
     }
 
     let mut prev_stat = g.get_statistics();
@@ -183,16 +227,45 @@ fn plot<G: Graph>(mut g: G, opts: PlotOptions) {
         print_statistics(&stat, &prev_stat);
         prev_stat = stat;
 
+        g.get_image(&mut raw_im);
+        for (dy, dx) in (0..opts.size[1]).cartesian_product(0..opts.size[0]) {
+            raw_im[PixelIndex::new(dx, dy)] = (0..opts.dilation_kernel.height())
+                .cartesian_product(0..opts.dilation_kernel.width())
+                .filter(|&(ky, kx)| opts.dilation_kernel[PixelIndex::new(kx, ky)])
+                .map(|(ky, kx)| raw_im[PixelIndex::new(dx + kx, dy + ky)])
+                .max()
+                .unwrap_or(Ternary::False);
+        }
+
+        let src_pixels = PixelRange::new(
+            PixelIndex::new(0, 0),
+            PixelIndex::new(opts.size[0], opts.size[1]),
+        );
         if let Some(im) = &mut gray_alpha_im {
-            g.get_image(im, LumaA([0, 255]), LumaA([0, 128]), LumaA([0, 0]));
+            for (src, dst) in src_pixels
+                .into_iter()
+                .map(|p| raw_im[p])
+                .zip(im.pixels_mut())
+            {
+                *dst = match src {
+                    Ternary::True => LumaA([0, 255]),
+                    Ternary::Uncertain => LumaA([0, 128]),
+                    Ternary::False => LumaA([0, 0]),
+                };
+            }
             im.save(&opts.output).expect("saving image failed");
         } else if let Some(im) = &mut rgb_im {
-            g.get_image(
-                im,
-                Rgb([0, 0, 0]),
-                Rgb([64, 128, 192]),
-                Rgb([255, 255, 255]),
-            );
+            for (src, dst) in src_pixels
+                .into_iter()
+                .map(|p| raw_im[p])
+                .zip(im.pixels_mut())
+            {
+                *dst = match src {
+                    Ternary::True => Rgb([0, 0, 0]),
+                    Ternary::Uncertain => Rgb([64, 128, 192]),
+                    Ternary::False => Rgb([255, 255, 255]),
+                };
+            }
             im.save(&opts.output).expect("saving image failed");
         }
 

--- a/rust/src/bin/graph.rs
+++ b/rust/src/bin/graph.rs
@@ -137,7 +137,8 @@ fn main() {
         ker
     };
 
-    let padded_size = [size[0] + 2 * dilation, size[1] + 2 * dilation];
+    let padding = dilation;
+    let padded_size = [size[0] + 2 * padding, size[1] + 2 * padding];
 
     let opts = PlotOptions {
         dilation_kernel,
@@ -157,7 +158,7 @@ fn main() {
                 region,
                 padded_size[0],
                 padded_size[1],
-                dilation,
+                padding,
                 mem_limit,
             ),
             opts,
@@ -168,7 +169,7 @@ fn main() {
                 region,
                 padded_size[0],
                 padded_size[1],
-                dilation,
+                padding,
                 mem_limit,
             ),
             opts,
@@ -179,7 +180,7 @@ fn main() {
                 region,
                 padded_size[0],
                 padded_size[1],
-                dilation,
+                padding,
                 mem_limit,
             ),
             opts,

--- a/rust/src/graph.rs
+++ b/rust/src/graph.rs
@@ -1,9 +1,5 @@
-use image::{ImageBuffer, Pixel};
-use std::{
-    error, fmt,
-    ops::{Deref, DerefMut},
-    time::Duration,
-};
+use crate::image::Image;
+use std::{error, fmt, time::Duration};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum GraphingErrorKind {
@@ -31,7 +27,7 @@ impl fmt::Display for GraphingError {
 
 impl error::Error for GraphingError {}
 
-/// Statistical information of graphing.
+/// Statistical information about graphing.
 #[derive(Clone, Debug)]
 pub struct GraphingStatistics {
     /// The number of times the relation has been evaluated.
@@ -46,16 +42,10 @@ pub struct GraphingStatistics {
 
 /// An implementation of a faithful graphing algorithm.
 pub trait Graph {
-    /// Puts the image of the graph to `im` with the specified colors.
-    fn get_image<P, Container>(
-        &self,
-        im: &mut ImageBuffer<P, Container>,
-        true_color: P,
-        uncertain_color: P,
-        false_color: P,
-    ) where
-        P: Pixel + 'static,
-        Container: Deref<Target = [P::Subpixel]> + DerefMut;
+    /// Puts the image of the graph to `im`.
+    ///
+    /// The image is vertically flipped, i.e., the pixel (0, 0) is the bottom-left corner of the graph.
+    fn get_image(&self, im: &mut Image<Ternary>);
 
     /// Returns the current statistics of graphing.
     fn get_statistics(&self) -> GraphingStatistics;
@@ -67,6 +57,28 @@ pub trait Graph {
 
     /// Returns the amount of memory allocated by `self` in bytes.
     fn size_in_heap(&self) -> usize;
+}
+
+/// A ternary value which could be either [`False`], [`Uncertain`] or [`True`].
+///
+/// The values are ordered as: [`False`] < [`Uncertain`] < [`True`].
+///
+/// The default value is [`Uncertain`].
+///
+/// [`False`]: Ternary::False
+/// [`True`]: Ternary::True
+/// [`Uncertain`]: Ternary::Uncertain
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum Ternary {
+    False,
+    Uncertain,
+    True,
+}
+
+impl Default for Ternary {
+    fn default() -> Self {
+        Ternary::Uncertain
+    }
 }
 
 pub mod constant;

--- a/rust/src/graph.rs
+++ b/rust/src/graph.rs
@@ -87,3 +87,16 @@ pub mod implicit;
 pub mod parametric;
 
 mod common;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ternary() {
+        assert_eq!(Ternary::default(), Ternary::Uncertain);
+
+        assert!(Ternary::False < Ternary::Uncertain);
+        assert!(Ternary::Uncertain < Ternary::True);
+    }
+}

--- a/rust/src/image.rs
+++ b/rust/src/image.rs
@@ -1,7 +1,7 @@
 use std::{
     mem::size_of,
     ops::{Index, IndexMut},
-    slice::Iter,
+    slice::{Iter, IterMut},
 };
 
 /// The maximum limit of the width/height of an [`Image`] in pixels.
@@ -31,9 +31,16 @@ impl<T: Clone + Copy + Default> Image<T> {
         self.height
     }
 
-    /// Returns an iterator over the pixels of the image in the lexicographical order of `(y, x)`.
+    /// Returns an iterator over the references to the pixels of the image
+    /// in the lexicographical order of `(y, x)`.
     pub fn pixels(&self) -> Iter<'_, T> {
         self.data.iter()
+    }
+
+    /// Returns an iterator over the mutable references to the pixels of the image
+    /// in the lexicographical order of `(y, x)`.
+    pub fn pixels_mut(&mut self) -> IterMut<'_, T> {
+        self.data.iter_mut()
     }
 
     /// Returns the size allocated by the [`Image`] in bytes.

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,12 +1,15 @@
 #![allow(clippy::float_cmp)]
 #![feature(box_patterns, box_syntax, once_cell)]
 
-pub use geom::Box2D;
-pub use graph::{
-    constant::Constant, explicit::Explicit, implicit::Implicit, parametric::Parametric, Graph,
-    GraphingStatistics,
+pub use crate::{
+    geom::Box2D,
+    graph::{
+        constant::Constant, explicit::Explicit, implicit::Implicit, parametric::Parametric, Graph,
+        GraphingStatistics, Ternary,
+    },
+    image::{Image, PixelIndex, PixelRange},
+    relation::{Relation, RelationType},
 };
-pub use relation::{Relation, RelationType};
 
 #[cfg(feature = "arb")]
 mod arb;

--- a/src/BigNumber.ts
+++ b/src/BigNumber.ts
@@ -1,0 +1,25 @@
+import { BigNumber } from "bignumber.js";
+
+declare module "bignumber.js" {
+  interface BigNumber {
+    ceil(): BigNumber;
+    floor(): BigNumber;
+  }
+}
+
+BigNumber.prototype.ceil = function (): BigNumber {
+  return this.integerValue(BigNumber.ROUND_CEIL);
+};
+
+BigNumber.prototype.floor = function (): BigNumber {
+  return this.integerValue(BigNumber.ROUND_FLOOR);
+};
+
+/**
+ * A shorthand for calling the constructor of {@link BigNumber}.
+ */
+function bignum(x: number): BigNumber {
+  return new BigNumber(x);
+}
+
+export { bignum, BigNumber };

--- a/src/GraphLayer.ts
+++ b/src/GraphLayer.ts
@@ -81,6 +81,7 @@ export class GraphLayer extends L.GridLayer {
       inner.style.width = GRAPH_TILE_SIZE + "px";
       inner.style.height = GRAPH_TILE_SIZE + "px";
       inner.style.background = this.lastGraph.color;
+      inner.style.webkitMaskSize = "100%";
       outer.appendChild(inner);
     }
     const tileId = this._tileCoordsToKey(coords);

--- a/src/GridLayer.ts
+++ b/src/GridLayer.ts
@@ -83,23 +83,15 @@ class Point {
   constructor(readonly x: BigNumber, readonly y: BigNumber) {}
 }
 
-//                      .5px
-//                       ┌─┐
-//
-//               |       | x (x1, y1)
-//            ---+-------+---
-//               |       |
-//               |       |
-//   .5px ┌      | x (x0, y0)
-//        └   ---+-------+---
-//               |       |
+const dst0 = new Point(bignum(0.5), bignum(TILE_SIZE - 0.5));
+const dst1 = new Point(bignum(TILE_SIZE + 0.5), bignum(-0.5));
 
 /**
  * Returns the destination points of the transformation from real coordinates
  * to pixel coordinates relative to the tile.
+ *
+ * @see {@link sourcePoints}
  */
-const dst0 = new Point(bignum(0.5), bignum(TILE_SIZE - 0.5));
-const dst1 = new Point(bignum(TILE_SIZE + 0.5), bignum(-0.5));
 function destinationPoints(): [Point, Point] {
   return [dst0, dst1];
 }
@@ -109,6 +101,24 @@ function destinationPoints(): [Point, Point] {
  * to pixel coordinates relative to the tile.
  * @param coords The coordinates of the tile.
  * @param widthPerTile The width of tiles at the level in real coordinates.
+ *
+ * The current configuration is shown below.
+ *
+ * @example
+ * ```text
+ *                     .5px
+ *                     ┌─┐
+ *
+ *             |       | X (x1, y1)
+ *          ---+-------+---
+ *             |       |
+ *             |       |
+ * .5px ┌      | X (x0, y0)
+ *      └   ---+-------+---
+ *             |       |
+ * ```
+ *
+ * @see {@link destinationPoints}
  */
 function sourcePoints(coords: L.Coords, widthPerTile: number): [Point, Point] {
   const w = bignum(widthPerTile);

--- a/src/main.ts
+++ b/src/main.ts
@@ -147,7 +147,7 @@ ipcMain.handle<ipc.RequestTile>(
     }
 
     const tile = rel.tiles.get(tileId);
-    const retinaScale = 1;
+    const retinaScale = 1 as number;
     if (tile === undefined) {
       // We offset the graph by 0.5px to place the origin at the center of a pixel.
       // The direction of offsetting must be coherent with the configuration of `GridLayer`.
@@ -188,7 +188,7 @@ ipcMain.handle<ipc.RequestTile>(
           (retinaScale * GRAPH_TILE_SIZE).toString(),
           (retinaScale * GRAPH_TILE_SIZE).toString(),
           "--dilate",
-          (retinaScale - 1).toString(),
+          retinaScale === 2 ? "0,0,0;1,1,0;1,1,0" : "1",
           "--gray-alpha",
           "--output",
           outFile,

--- a/src/main.ts
+++ b/src/main.ts
@@ -147,7 +147,7 @@ ipcMain.handle<ipc.RequestTile>(
     }
 
     const tile = rel.tiles.get(tileId);
-    const retinaScale = 2;
+    const retinaScale = 1;
     if (tile === undefined) {
       // We offset the graph by 0.5px to place the origin at the center of a pixel.
       // The direction of offsetting must be coherent with the configuration of `GridLayer`.

--- a/src/main.ts
+++ b/src/main.ts
@@ -149,6 +149,11 @@ ipcMain.handle<ipc.RequestTile>(
     const tile = rel.tiles.get(tileId);
     const retinaScale = 2;
     if (tile === undefined) {
+      // We offset the graph by 0.5px to place the origin at the center of a pixel.
+      // The direction of offsetting must be coherent with the configuration of `GridLayer`.
+      // We also add asymmetric perturbation to the offset so that
+      // points with simple coordinates may not be located on pixel boundaries,
+      // which could make lines such as `y = x` look thicker.
       const pixelOffsetX = bignum(
         (0.5 + 1.2345678901234567e-3) / (retinaScale * GRAPH_TILE_SIZE)
       );

--- a/src/main.ts
+++ b/src/main.ts
@@ -147,9 +147,14 @@ ipcMain.handle<ipc.RequestTile>(
     }
 
     const tile = rel.tiles.get(tileId);
+    const retina_scale = 2;
     if (tile === undefined) {
-      const purturb_x = bignum(0.50123456789012345 / GRAPH_TILE_SIZE);
-      const purturb_y = bignum(0.50234567890123456 / GRAPH_TILE_SIZE);
+      const purturb_x = bignum(
+        0.50123456789012345 / (retina_scale * GRAPH_TILE_SIZE)
+      );
+      const purturb_y = bignum(
+        0.50234567890123456 / (retina_scale * GRAPH_TILE_SIZE)
+      );
       const widthPerTile = bignum(2 ** (BASE_ZOOM_LEVEL - coords.z));
       const x0 = widthPerTile.times(bignum(coords.x).minus(purturb_x));
       const x1 = widthPerTile.times(bignum(coords.x + 1).minus(purturb_x));
@@ -175,8 +180,10 @@ ipcMain.handle<ipc.RequestTile>(
           y0.toString(),
           y1.toString(),
           "--size",
-          GRAPH_TILE_SIZE.toString(),
-          GRAPH_TILE_SIZE.toString(),
+          (retina_scale * GRAPH_TILE_SIZE).toString(),
+          (retina_scale * GRAPH_TILE_SIZE).toString(),
+          "--dilate",
+          (retina_scale - 1).toString(),
           "--gray-alpha",
           "--output",
           outFile,


### PR DESCRIPTION
Merge #285 first.

## Tasks

- [x] Opt-out the high-res option
- [x] The x-axis of the grid does not match with `y = 0`

## Future Tasks

- Implement settings/preferences
  Mention there that when the option is on, graphing can take 4x longer than when it is off.
