### PR TITLE
Make graph origin exactly match the map origin

### DIFF
--- a/rust/src/graph.rs
+++ b/rust/src/graph.rs
@@ -59,6 +59,14 @@ pub trait Graph {
     fn size_in_heap(&self) -> usize;
 }
 
+#[derive(Clone, Debug)]
+pub struct Padding {
+    pub bottom: u32,
+    pub left: u32,
+    pub right: u32,
+    pub top: u32,
+}
+
 /// A ternary value which could be either [`False`], [`Uncertain`] or [`True`].
 ///
 /// The values are ordered as: [`False`] < [`Uncertain`] < [`True`].

--- a/rust/src/graph/implicit.rs
+++ b/rust/src/graph/implicit.rs
@@ -4,7 +4,7 @@ use crate::{
     geom::{Box2D, Transform2D},
     graph::{
         common::{point_interval, simple_fraction, subpixel_outer, PixelState, QueuedBlockIndex},
-        Graph, GraphingError, GraphingErrorKind, GraphingStatistics, Ternary,
+        Graph, GraphingError, GraphingErrorKind, GraphingStatistics, Padding, Ternary,
     },
     image::{Image, PixelIndex, PixelRange},
     interval_set::{DecSignSet, SignSet},
@@ -38,7 +38,7 @@ impl Implicit {
         region: Box2D,
         im_width: u32,
         im_height: u32,
-        padding: u32,
+        padding: Padding,
         mem_limit: usize,
     ) -> Self {
         assert_eq!(rel.relation_type(), RelationType::Implicit);
@@ -57,12 +57,12 @@ impl Implicit {
             im_to_real: Transform2D::new(
                 [
                     Region::new(
-                        point_interval(padding as f64),
-                        point_interval(padding as f64),
+                        point_interval(padding.left as f64),
+                        point_interval(padding.bottom as f64),
                     ),
                     Region::new(
-                        point_interval((im_width - padding) as f64),
-                        point_interval((im_height - padding) as f64),
+                        point_interval((im_width - padding.right) as f64),
+                        point_interval((im_height - padding.top) as f64),
                     ),
                 ],
                 [

--- a/rust/src/graph/parametric.rs
+++ b/rust/src/graph/parametric.rs
@@ -3,7 +3,7 @@ use crate::{
     geom::{Box2D, Transform2D},
     graph::{
         common::{point_interval, point_interval_possibly_infinite, PixelState, QueuedBlockIndex},
-        Graph, GraphingError, GraphingErrorKind, GraphingStatistics, Ternary,
+        Graph, GraphingError, GraphingErrorKind, GraphingStatistics, Padding, Ternary,
     },
     image::{Image, PixelIndex, PixelRange},
     interval_set::{DecSignSet, SignSet, TupperIntervalSet},
@@ -40,7 +40,7 @@ impl Parametric {
         region: Box2D,
         im_width: u32,
         im_height: u32,
-        padding: u32,
+        padding: Padding,
         mem_limit: usize,
     ) -> Self {
         assert_eq!(rel.relation_type(), RelationType::Parametric);
@@ -63,12 +63,12 @@ impl Parametric {
                 ],
                 [
                     Region::new(
-                        point_interval(padding as f64),
-                        point_interval(padding as f64),
+                        point_interval(padding.left as f64),
+                        point_interval(padding.bottom as f64),
                     ),
                     Region::new(
-                        point_interval((im_width - padding) as f64),
-                        point_interval((im_height - padding) as f64),
+                        point_interval((im_width - padding.right) as f64),
+                        point_interval((im_height - padding.top) as f64),
                     ),
                 ],
             ),

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -5,7 +5,7 @@ pub use crate::{
     geom::Box2D,
     graph::{
         constant::Constant, explicit::Explicit, implicit::Implicit, parametric::Parametric, Graph,
-        GraphingStatistics, Ternary,
+        GraphingStatistics, Padding, Ternary,
     },
     image::{Image, PixelIndex, PixelRange},
     relation::{Relation, RelationType},

--- a/src/GraphLayer.ts
+++ b/src/GraphLayer.ts
@@ -1,6 +1,6 @@
 import { Unsubscribe } from "@reduxjs/toolkit";
 import * as L from "leaflet";
-import { GRAPH_TILE_SIZE } from "./constants";
+import { EXTENDED_GRAPH_TILE_SIZE, GRAPH_TILE_SIZE } from "./constants";
 import * as ipc from "./ipc";
 import { Graph, setGraphIsProcessing } from "./models/graph";
 import { Store } from "./models/store";
@@ -81,7 +81,9 @@ export class GraphLayer extends L.GridLayer {
       inner.style.width = GRAPH_TILE_SIZE + "px";
       inner.style.height = GRAPH_TILE_SIZE + "px";
       inner.style.background = this.lastGraph.color;
-      inner.style.webkitMaskSize = "100%";
+      inner.style.webkitMaskPosition =
+        "top -0.4990234375px left -0.4990234375px";
+      inner.style.webkitMaskSize = EXTENDED_GRAPH_TILE_SIZE + "px";
       outer.appendChild(inner);
     }
     const tileId = this._tileCoordsToKey(coords);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,3 +7,19 @@ export const BASE_ZOOM_LEVEL = 512;
  * The width/height of graph tiles in pixels.
  */
 export const GRAPH_TILE_SIZE = 256;
+
+/**
+ * The extra width/height added to {@link GRAPH_TILE_SIZE} in pixels.
+ *
+ * The value is 1 and fixed, but defined as a constant for readability.
+ *
+ * Graph tiles are extended by 1px on the right and the bottom sides
+ * then translated by -0.5px both horizontally and vertically
+ * to place the origin at the corners of the center tiles.
+ */
+export const GRAPH_TILE_EXTENSION = 1;
+
+/**
+ * The sum of {@link GRAPH_TILE_SIZE} and {@link GRAPH_TILE_EXTENSION}.
+ */
+export const EXTENDED_GRAPH_TILE_SIZE = GRAPH_TILE_SIZE + GRAPH_TILE_EXTENSION;

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,12 @@ import * as os from "os";
 import * as path from "path";
 import { pathToFileURL } from "url";
 import { bignum } from "./BigNumber";
-import { BASE_ZOOM_LEVEL, GRAPH_TILE_SIZE } from "./constants";
+import {
+  BASE_ZOOM_LEVEL,
+  EXTENDED_GRAPH_TILE_SIZE,
+  GRAPH_TILE_EXTENSION,
+  GRAPH_TILE_SIZE,
+} from "./constants";
 import * as ipc from "./ipc";
 
 const fsPromises = fs.promises;
@@ -163,8 +168,8 @@ ipcMain.handle<ipc.RequestTile>(
       const widthPerTile = bignum(2 ** (BASE_ZOOM_LEVEL - coords.z));
       const x0 = widthPerTile.times(bignum(coords.x).minus(pixelOffsetX));
       const x1 = widthPerTile.times(bignum(coords.x + 1).minus(pixelOffsetX));
-      const y0 = widthPerTile.times(bignum(-coords.y - 1).minus(pixelOffsetY));
-      const y1 = widthPerTile.times(bignum(-coords.y).minus(pixelOffsetY));
+      const y0 = widthPerTile.times(bignum(-coords.y - 1).plus(pixelOffsetY));
+      const y1 = widthPerTile.times(bignum(-coords.y).plus(pixelOffsetY));
 
       const outFile = path.join(rel.outDir, rel.nextTileNumber + ".png");
       rel.nextTileNumber++;
@@ -184,10 +189,14 @@ ipcMain.handle<ipc.RequestTile>(
           y0.toString(),
           y1.toString(),
           "--size",
-          (retinaScale * GRAPH_TILE_SIZE).toString(),
-          (retinaScale * GRAPH_TILE_SIZE).toString(),
+          (retinaScale * EXTENDED_GRAPH_TILE_SIZE).toString(),
+          (retinaScale * EXTENDED_GRAPH_TILE_SIZE).toString(),
+          "--padding-right",
+          (retinaScale * GRAPH_TILE_EXTENSION).toString(),
+          "--padding-bottom",
+          (retinaScale * GRAPH_TILE_EXTENSION).toString(),
           "--dilate",
-          retinaScale === 2 ? "0,0,0;1,1,0;1,1,0" : "1",
+          retinaScale === 2 ? "1,1,0;1,1,0;0,0,0" : "1",
           "--gray-alpha",
           "--output",
           outFile,


### PR DESCRIPTION
Merge #285 first.

The following combinations must be supported by `GraphLayer` and `GridLayer`:

|                       | @1x Tile | @2x Tile |
| --------------------- | -------- | -------- |
| `devicePixelRatio: 1` | ✅       |          |
| `devicePixelRatio: 2` | ✅       | ✅       |

